### PR TITLE
Suggestion: Document notebook as `sub-article`

### DIFF
--- a/01-approach.md
+++ b/01-approach.md
@@ -26,7 +26,7 @@ In some cases, it is possible to collapse all computational information into a s
 
 > The purple and orange components, interactive figure or other computational outputs, are created in a computational notebook and subsequently used in other narrative or presentation-focused scientific article.
 
-For maximum downstream utility, these notebooks should be included in the full JATS XML. For this purpose we suggest the use of the `sub-article` element for each notebook, or in the 1:1 relationship, the `article` itself. The way in which this XML document is consumed in a viewing context, can of course diverge from the requirements of a single-XML document. With this approach, JATS can take a step towards more fully representing the “research compendium”[^compendium] and align to existing researcher practices.
+For maximum downstream utility, these notebooks should be included in the full JATS XML. For this purpose we suggest the use of the `sub-article` element for each notebook whether that notebook represents the source notebook for the article itself or a notebook that is used to produce a figure, table, or other element of the article. The way in which this XML document is consumed in a viewing context, can of course diverge from the requirements of a single-XML document. With this approach, JATS can take a step towards more fully representing the “research compendium”[^compendium] and align to existing researcher practices.
 
 [^compendium]: For examples and explanations of this, see [The Turing Way](https://the-turing-way.netlify.app/reproducible-research/compendia), any step towards representing the full reproduction of research in the archived VoR is valuable.
 


### PR DESCRIPTION
Proposal: 

Perhaps we should propose that the even a notebook that represents the source of the article itself be included as a `sub-article` (and `xref`ed as appropriate). 

One of the great things about the sub-article approach is that it makes the source code that produces elements of the article available to reviewers or the manuscript system. In the case of a single notebook that is used to produce the article itself, the rendered JATS of the notebook may not include source code (and will have the narrative type structure). If we additionally include a `notebook` style rendering of the source notebook as a `sub-article`, the source code and computional version of the article could be viewed / utilized as well.

This approach would allow us to focus on producing

- The JATS article itself to be a narrative focused rendering of JATS with `xrefs` to `sub-article`s. It will likely do things like exclude the code that generates figures in order to provide a more typical / usable article rendering.
- The `sub-article`s that represent the notebooks (as described in the next document), and including `self-uri`, `supplementary-materials` and so on that provide all the notebook metadata (including ultimately the execution information).

What do you think?