### PR TITLE
Proposal: Strike Dependencies in JATS

### DIFF
--- a/02-notebooks-as-jats.md
+++ b/02-notebooks-as-jats.md
@@ -47,16 +47,6 @@ If the document is stored by the publisher directly, a `supplementary-material` 
 
 **TODO:** specific-use: the notebooks can either be the source or an export format (e.g. in using quarto/rmd). Should we list both here, with different content types?
 
-### Indexing Dependencies
-
-From an XML indexing and archiving perspective, it is advantageous to list the requirements to run a computational notebook. These should be captured in such a way that they can give credit to scientific packages, for example, answering questions such as "how many articles used `numpy >= 1.22` this year?".
-
-These should be included in the main `front` of the entire article, not each sub-article (we believe this is a reasonable constraint) that specificies a single computational article for each article, rather than each notebook.
-
-**TODO:** Not sure how to represent this.
-
-Note that the purpose of this is not to replace tools like `requirements.txt`, but to provide information to existing indexing and archiving tools to make use of these data in addition to other ways to keep the computational notebooks fully supported.
-
 ### Notebook as the main article
 
 It is possible to use a notebook as the main article, however, the structure of the JATS in this case is _not_ dictated by the notebook structure, but by the narrative structure.


### PR DESCRIPTION
While I agree that is very desirable, I do think we should consider either striking this for the time being or consider marking it aspirational / stretch. A couple of thoughts as to why:

- Each language has its own mechanism for managing dependencies
- Many languages have more than one way to manage dependencies without a dominant player
- Either JATS will have to store a general XML representation of dependencies, in which case the tool authoring the JATS will need to know how to read and create the dependencies from all the different ways of representing dependencies, or we will store a path to a dependencies file and the consumer of the JATS will have to know how to deal with it.
- I think a dependency list would be difficult to add directly using the existing JATS elements (perhaps `custom-meta-group`?), whereas as I believe everything else we're doing layers on to existing elements without too much stretching of their meanings.

Curious as to what you think...