### PR TITLE
⛵️ Add Jeff Beck as contributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,22 @@ Current contributors to these documents are:
 Rowan Cockett
 : **Roles**: Writing – Original Draft Preparation, Software, Visualization
 : **Affiliation**: Curvenote Inc
+: **GitHub**: @rowanc1
 
 J.J. Allaire
 : **Roles**: Writing – Original Draft Preparation, Software
 : **Affiliation**: Posit Software PBC
+: **GitHub**: @jjallaire
 
 Charles Teague
 : **Roles**: Writing – Original Draft Preparation, Software
 : **Affiliation**: Posit Software PBC
+: **GitHub**: @dragonstyle
 
 Jeffrey Beck
 : **Roles**: Writing – Review & Editing, Conceptualization
 : **Affiliation**: National Center for Biotechnology Information, National Library of Medicine, National Institutes of Health, Bethesda, MD 20894, USA.
+: **GitHub**: @jeffbeckncbi
 
 :::
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The AGU _Notebooks Now_ working groups will be participating and leading the cre
 Current contributors to these documents are:
 
 Rowan Cockett
-: **Roles**: Writing – Original Draft Preparation, Software
+: **Roles**: Writing – Original Draft Preparation, Software, Visualization
 : **Affiliation**: Curvenote Inc
 
 J.J. Allaire
@@ -31,6 +31,11 @@ J.J. Allaire
 Charles Teague
 : **Roles**: Writing – Original Draft Preparation, Software
 : **Affiliation**: Posit Software PBC
+
+Jeffrey Beck
+: **Roles**: Writing – Review & Editing, Conceptualization
+: **Affiliation**: National Center for Biotechnology Information, National Library of Medicine, National Institutes of Health, Bethesda, MD 20894, USA.
+
 :::
 
 At AGU Notebooks Now, we looked at the academic publishing workflows around notebooks as a number of steps: (1) pre-submission, (2) submission & metadata, (3) editorial & peer review, and (4) production & post production. Each step of this workflow and how they fit together may be required to change or adapt when considering computational content in notebooks as a core publication artifact.


### PR DESCRIPTION
In conversation with @jeffbeckncbi today, he expressed interest in being a contributor to these documents as they come together. Already he is giving a lot of advice and perspective on various tags and approach, and from his perspective at NCBI has a wide view on how JATS is used in science communication.

Jeff, I put the initial CRediT Roles as `Writing – Review & Editing` and `Conceptualization` -- these can evolve any time. (@dragonstyle reminded me yesterday that you were the one that suggested the `sub-article` approach in our Nov. meeting).

Looking forward to working with you on bringing these standards to life. 🚀