### PR TITLE
👩‍🔬 Draft of inline expressions as <notes>

### DIFF
--- a/docs/02-notebooks-as-jats.md
+++ b/docs/02-notebooks-as-jats.md
@@ -286,7 +286,7 @@ When {eval}`polynomial` is expanded, it becomes {eval}`expand(polynomial)`.
   </code>
 </sec>
 <p>
-  When <xref ref-type="custom" custom-type="expression" rid="eval-1"><inline-formula><tex-math><![CDATA[ x \\left(x + 2 y\\right) ]]></tex-math></xref> is expanded, it becomes <xref ref-type="custom" custom-type="expression" rid="eval-2"><inline-formula><tex-math><![CDATA[ x^{2} + 2 x y ]]></tex-math></xref>.
+  When <xref ref-type="custom" custom-type="expression" rid="eval-1"><inline-formula><tex-math><![CDATA[ x \\left(x + 2 y\\right) ]]></tex-math></inline-formula></xref> is expanded, it becomes <xref ref-type="custom" custom-type="expression" rid="eval-2"><inline-formula><tex-math><![CDATA[ x^{2} + 2 x y ]]></tex-math></inline-formula></xref>.
 </p>
 ...
 <back>


### PR DESCRIPTION
This is a draft of inline expressions which is consistent with other notebook cells/content as well as solves some of the challenges with single notebooks that @dragonstyle raised in #2.

The basic idea is to store these as "footnotes" that are then referenced throughout the document. However, `fn` presents a bunch of other problems due to what it can have in it -- `<notes>` on the other hand I think is perfect (maybe @jeffbeckncbi has thoughts?!).

![image](https://user-images.githubusercontent.com/913249/233493578-e7914668-c35f-43f6-a23a-b9893574bf5e.png)

This also I think gets around the main article not having to be a notebook. We can also potentially look to `milestone-start` to record the boundaries of the markdown cells. For the notebook-is-the-article, we should just have a specific use on the sections, and I think we are good to go?!

I am less sure about the notebook/article differences, however, the inline expressions I think are well thought out! Looking forward to feedback.